### PR TITLE
CFSM: resolves #1 Add user instance data 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ project(CFSM
         HOMEPAGE_URL "https://github.com/nhjschulz/cfsm"
 )
 
+# ******************************************************************************
+# Build CFSM as a static link library which is used by example code.
+# ******************************************************************************
+
 add_library(cfsm 
     src/c_fsm.c
 )
@@ -21,6 +25,19 @@ add_library(cfsm
 target_include_directories(cfsm
     PUBLIC "src"
 )
+
+# ******************************************************************************
+# Enable strict compiler warnings 
+# ******************************************************************************
+ 
+if (MSVC)
+    # warning level 4
+    add_compile_options(/W4)
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 
 set (CFSM_EXAMPLE_MARIO_SRC 
     "examples/mario/main.c"

--- a/doc/mario_classdiagram.puml
+++ b/doc/mario_classdiagram.puml
@@ -42,7 +42,7 @@ package "Mario Example" {
 }
 
 package "CFSM" {
-    class cfsm_Fsm  {
+    class cfsm_Ctx  {
         +cfsm_init()
         +cfsm_transition( enterFunc: cfsm_TransitionFunction)
         +cfsm_process()
@@ -57,7 +57,7 @@ package "CFSM" {
     }
 }
 
-cfsm_Fsm --  Operations
+cfsm_Ctx --  Operations
 SuperMario .u-|> Operations
 CapeMario  .u-|> Operations
 FireMario  .u-|> Operations
@@ -67,7 +67,7 @@ SmallMario .u-|> Operations
 states .> Mario : update 
 
 SmallMario <.. Main  
-Main ..> cfsm_Fsm : init as SmallMario\nprocessing and\n event signalling 
+Main ..> cfsm_Ctx : init as SmallMario\nprocessing and\n event signalling 
 
 MarioVariant .l. MarioData
 MarioEvent .r. MarioData

--- a/examples/mario/main.c
+++ b/examples/mario/main.c
@@ -65,12 +65,14 @@
 
 int main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
     
-    cfsm_Fsm marioFsm;
+    cfsm_Ctx marioFsm;
 
     puts ("Mario cfsm example: \n");
 
-    cfsm_init(&marioFsm);
+    cfsm_init(&marioFsm, NULL);
     cfsm_transition(&marioFsm, SmallMario_onEnter);
 
     for(;;) 

--- a/examples/mario/mario.c
+++ b/examples/mario/mario.c
@@ -115,6 +115,10 @@ void mario_updateCoins(MarioEvent e)
 
         case MONSTER:
             break;
+        
+        case QUIT:
+        case NOP:
+            break;
     }
 
     if (mario.coins > 5000)

--- a/examples/mario/states/cape_mario.c
+++ b/examples/mario/states/cape_mario.c
@@ -58,9 +58,9 @@
  * Prototypes
  *****************************************************************************/
 
-static void CapeMario_onEvent(cfsm_Fsm * state, int eventId);
-static void CapeMario_onProcess(cfsm_Fsm * state);
-static void CapeMario_onLeave(cfsm_Fsm * state);
+static void CapeMario_onEvent(cfsm_Ctx * state, int eventId);
+static void CapeMario_onProcess(cfsm_Ctx * state);
+static void CapeMario_onLeave(cfsm_Ctx * state);
 
 /******************************************************************************
  * Variables
@@ -70,7 +70,7 @@ static void CapeMario_onLeave(cfsm_Fsm * state);
  * External functions
  *****************************************************************************/
 
-void CapeMario_onEnter(cfsm_Fsm * fsm)
+void CapeMario_onEnter(cfsm_Ctx * fsm)
 {
     puts("CapeMario_onEnter()...");
 
@@ -85,8 +85,9 @@ void CapeMario_onEnter(cfsm_Fsm * fsm)
  * Local functions
  *****************************************************************************/
 
-static void CapeMario_onEvent(cfsm_Fsm * fsm, int eventId)
+static void CapeMario_onEvent(cfsm_Ctx * fsm, int eventId)
 {
+    (void)fsm;
     mario_updateCoins(eventId);
 
     switch(eventId)
@@ -109,13 +110,15 @@ static void CapeMario_onEvent(cfsm_Fsm * fsm, int eventId)
     }
 }
 
-static void CapeMario_onProcess(cfsm_Fsm * fsm)
+static void CapeMario_onProcess(cfsm_Ctx * fsm)
 {
+    (void)fsm;
     puts("CapeMario_onProces(): Look, I can fly!");
 }
 
-static void CapeMario_onLeave(cfsm_Fsm * fsm)
+static void CapeMario_onLeave(cfsm_Ctx * fsm)
 {
+    (void)fsm;
     puts("CapeMario_onLeave() ...");
 }
 

--- a/examples/mario/states/cape_mario.h
+++ b/examples/mario/states/cape_mario.h
@@ -55,7 +55,7 @@
 /******************************************************************************
  * Functions
  *****************************************************************************/
-void CapeMario_onEnter(cfsm_Fsm * state);
+void CapeMario_onEnter(cfsm_Ctx * state);
 
 
 #endif /* SUPER_MARIO_H */

--- a/examples/mario/states/dead_mario.c
+++ b/examples/mario/states/dead_mario.c
@@ -54,7 +54,7 @@
  * Prototypes
  *****************************************************************************/
 
-static void DeadMario_onProcess(cfsm_Fsm * state);
+static void DeadMario_onProcess(cfsm_Ctx * state);
 
 /******************************************************************************
  * Variables
@@ -64,7 +64,7 @@ static void DeadMario_onProcess(cfsm_Fsm * state);
  * External functions
  *****************************************************************************/
 
-void DeadMario_onEnter(cfsm_Fsm * fsm)
+void DeadMario_onEnter(cfsm_Ctx * fsm)
 {
     puts("DeadMario_onEnter()...");
 
@@ -77,8 +77,9 @@ void DeadMario_onEnter(cfsm_Fsm * fsm)
  * Local functions
  *****************************************************************************/
 
-static void DeadMario_onProcess(cfsm_Fsm * fsm)
+static void DeadMario_onProcess(cfsm_Ctx * fsm)
 {
+    (void)fsm;
     puts("DeadMario_onProces(): He's dead Jim!");
 }
 

--- a/examples/mario/states/dead_mario.h
+++ b/examples/mario/states/dead_mario.h
@@ -55,7 +55,7 @@
 /******************************************************************************
  * Functions
  *****************************************************************************/
-void DeadMario_onEnter(cfsm_Fsm * state);
+void DeadMario_onEnter(cfsm_Ctx * state);
 
 
 #endif /* DEAD_MARIO_H */

--- a/examples/mario/states/fire_mario.c
+++ b/examples/mario/states/fire_mario.c
@@ -60,9 +60,9 @@
  * Prototypes
  *****************************************************************************/
 
-static void FireMario_onEvent(cfsm_Fsm * state, int eventId);
-static void FireMario_onProcess(cfsm_Fsm * state);
-static void FireMario_onLeave(cfsm_Fsm * state);
+static void FireMario_onEvent(cfsm_Ctx * state, int eventId);
+static void FireMario_onProcess(cfsm_Ctx * state);
+static void FireMario_onLeave(cfsm_Ctx * state);
 
 /******************************************************************************
  * Variables
@@ -72,7 +72,7 @@ static void FireMario_onLeave(cfsm_Fsm * state);
  * External functions
  *****************************************************************************/
 
-void FireMario_onEnter(cfsm_Fsm * fsm)
+void FireMario_onEnter(cfsm_Ctx * fsm)
 {
     puts("FireMario_onEnter()...");
 
@@ -87,7 +87,7 @@ void FireMario_onEnter(cfsm_Fsm * fsm)
  * Local functions
  *****************************************************************************/
 
-void FireMario_onEvent(cfsm_Fsm * fsm, int eventId)
+void FireMario_onEvent(cfsm_Ctx * fsm, int eventId)
 {
     mario_updateCoins(eventId);
 
@@ -111,13 +111,17 @@ void FireMario_onEvent(cfsm_Fsm * fsm, int eventId)
     }
 }
 
-void FireMario_onProcess(cfsm_Fsm * fsm)
+void FireMario_onProcess(cfsm_Ctx * fsm)
 {
+    (void)fsm;
+
     puts("FireMario_onProces(): I throw fire balls!");
 }
 
-void FireMario_onLeave(cfsm_Fsm * fsm)
+void FireMario_onLeave(cfsm_Ctx * fsm)
 {
+    (void)fsm;
+    
     puts("FireMario_onLeave() ...");
 }
 

--- a/examples/mario/states/fire_mario.h
+++ b/examples/mario/states/fire_mario.h
@@ -55,7 +55,7 @@
 /******************************************************************************
  * Functions
  *****************************************************************************/
-void FireMario_onEnter(cfsm_Fsm * state);
+void FireMario_onEnter(cfsm_Ctx * state);
 
 
 #endif /* FIRE_MARIO_H */

--- a/examples/mario/states/small_mario.c
+++ b/examples/mario/states/small_mario.c
@@ -58,9 +58,9 @@
  * Prototypes
  *****************************************************************************/
 
-static void SmallMario_onEvent(cfsm_Fsm * state, int eventId);
-static void SmallMario_onProcess(cfsm_Fsm * state);
-static void SmallMario_onLeave(cfsm_Fsm * state);
+static void SmallMario_onEvent(cfsm_Ctx * state, int eventId);
+static void SmallMario_onProcess(cfsm_Ctx * state);
+static void SmallMario_onLeave(cfsm_Ctx * state);
 
 /******************************************************************************
  * Variables
@@ -70,7 +70,7 @@ static void SmallMario_onLeave(cfsm_Fsm * state);
  * External functions
  *****************************************************************************/
 
-void SmallMario_onEnter(cfsm_Fsm * fsm)
+void SmallMario_onEnter(cfsm_Ctx * fsm)
 {
     puts("SmallMario_onEnter()...");
 
@@ -85,8 +85,10 @@ void SmallMario_onEnter(cfsm_Fsm * fsm)
  * Local functions
  *****************************************************************************/
 
-static void SmallMario_onEvent(cfsm_Fsm * fsm, int eventId)
+static void SmallMario_onEvent(cfsm_Ctx * fsm, int eventId)
 {
+    (void)fsm;
+    
     mario_updateCoins(eventId);
 
     switch(eventId)
@@ -112,13 +114,16 @@ static void SmallMario_onEvent(cfsm_Fsm * fsm, int eventId)
     }
 }
 
-static void SmallMario_onProcess(cfsm_Fsm * fsm)
+static void SmallMario_onProcess(cfsm_Ctx * fsm)
 {
+    (void)fsm;
+
     puts("SmallMario_onProces(): It's me, Mario!");
 }
 
-static void SmallMario_onLeave(cfsm_Fsm * fsm)
+static void SmallMario_onLeave(cfsm_Ctx * fsm)
 {
+    (void)fsm;
     puts("SmallMario_onLeave() ...");
 }
 

--- a/examples/mario/states/small_mario.h
+++ b/examples/mario/states/small_mario.h
@@ -55,7 +55,7 @@
 /******************************************************************************
  * Functions
  *****************************************************************************/
-void SmallMario_onEnter(cfsm_Fsm * state);
+void SmallMario_onEnter(cfsm_Ctx * state);
 
 
 #endif /* SMALL_MARIO_H */

--- a/examples/mario/states/super_mario.c
+++ b/examples/mario/states/super_mario.c
@@ -58,9 +58,9 @@
  * Prototypes
  *****************************************************************************/
 
-static void SuperMario_onEvent(cfsm_Fsm * state, int eventId);
-static void SuperMario_onProcess(cfsm_Fsm * state);
-static void SuperMario_onLeave(cfsm_Fsm * state);
+static void SuperMario_onEvent(cfsm_Ctx * state, int eventId);
+static void SuperMario_onProcess(cfsm_Ctx * state);
+static void SuperMario_onLeave(cfsm_Ctx * state);
 
 /******************************************************************************
  * Variables
@@ -70,7 +70,7 @@ static void SuperMario_onLeave(cfsm_Fsm * state);
  * External functions
  *****************************************************************************/
 
-void SuperMario_onEnter(cfsm_Fsm * fsm)
+void SuperMario_onEnter(cfsm_Ctx * fsm)
 {
     puts("SuperMario_onEnter()...");
 
@@ -85,7 +85,7 @@ void SuperMario_onEnter(cfsm_Fsm * fsm)
  * Local functions
  *****************************************************************************/
 
-static void SuperMario_onEvent(cfsm_Fsm * fsm, int eventId)
+static void SuperMario_onEvent(cfsm_Ctx * fsm, int eventId)
 {
     mario_updateCoins(eventId);
 
@@ -109,13 +109,17 @@ static void SuperMario_onEvent(cfsm_Fsm * fsm, int eventId)
     }
 }
 
-static void SuperMario_onProcess(cfsm_Fsm * fsm)
+static void SuperMario_onProcess(cfsm_Ctx * fsm)
 {
+    (void)fsm;
+
     puts("SuperMario_onProces(): It's me, SUPER Mario!");
 }
 
-static void SuperMario_onLeave(cfsm_Fsm * fsm)
+static void SuperMario_onLeave(cfsm_Ctx * fsm)
 {
+    (void)fsm;
+    
     puts("SuperMario_onLeave() ...");
 }
 

--- a/examples/mario/states/super_mario.h
+++ b/examples/mario/states/super_mario.h
@@ -55,7 +55,7 @@
 /******************************************************************************
  * Functions
  *****************************************************************************/
-void SuperMario_onEnter(cfsm_Fsm * state);
+void SuperMario_onEnter(cfsm_Ctx * state);
 
 
 #endif /* SUPER_MARIO_H */

--- a/src/c_fsm.c
+++ b/src/c_fsm.c
@@ -60,13 +60,12 @@
  * External functions
  *****************************************************************************/
 
-void cfsm_init(struct cfsm_Fsm * fsm)
+void cfsm_init(struct cfsm_Ctx * fsm, cfsm_InstanceDataPtr instanceData)
 {
-    *fsm = (cfsm_Fsm) {0, 0, 0, 0};
+    *fsm = (cfsm_Ctx) {instanceData, 0, 0, 0, 0};
 }
 
-
-void cfsm_transition(struct cfsm_Fsm * fsm, cfsm_TransitionFunction enterFunc)
+void cfsm_transition(struct cfsm_Ctx * fsm, cfsm_TransitionFunction enterFunc)
 {
     /* Call former state leave operations if present. */
     if ((cfsm_TransitionFunction)0 != fsm->onLeave)
@@ -77,7 +76,10 @@ void cfsm_transition(struct cfsm_Fsm * fsm, cfsm_TransitionFunction enterFunc)
     /* Set enter function pointer and clear all other handler. They
      * get set by the enter function if needed.
      */
-    *fsm =  (cfsm_Fsm) { enterFunc, 0, 0, 0 };
+    fsm->onEnter  = enterFunc;
+    fsm->onEvent  = (cfsm_EventFunction)0;
+    fsm->onLeave  = (cfsm_TransitionFunction)0;
+    fsm->onProcess= (cfsm_ProcessFunction)0;
 
     /* Call enter function NULL checked. It might be NULL to "disable"
      * all FSM operations.
@@ -88,7 +90,7 @@ void cfsm_transition(struct cfsm_Fsm * fsm, cfsm_TransitionFunction enterFunc)
     }
 }
 
-void cfsm_process(struct cfsm_Fsm * fsm)
+void cfsm_process(struct cfsm_Ctx * fsm)
 {
     /* Delegate to state processing operation if handler is defined. */
     if ((cfsm_ProcessFunction)0 != fsm->onProcess)
@@ -97,7 +99,7 @@ void cfsm_process(struct cfsm_Fsm * fsm)
     }
 }
 
-void cfsm_event(struct cfsm_Fsm * fsm, int eventId)
+void cfsm_event(struct cfsm_Ctx * fsm, int eventId)
 {
     /* Delegate to state event processing if handler is defined. */
     if ((cfsm_EventFunction)0 != fsm->onEvent)


### PR DESCRIPTION
Extend CFSM context to include a instance data pointer. This is used to run multiple instances of the same FSM.

Renamed context from cfsm_Cfsm to cfsm_Ctx.
This better reflects now what it is.

Side: Compiler warning removal.